### PR TITLE
Add #[const_trait] to Hashable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ const INVALID_INDEX32: u32 = INVALID_INDEX as u32;
 
 const HASH_MASK: u64 = 0x0000_00FF_FFFF_FFFF;
 
+#[const_trait]
 pub trait Hashable {
     fn to_hash(self) -> Hash40;
 }


### PR DESCRIPTION
Fixes the crate's compile errors.
